### PR TITLE
Support loading ecto conditionally

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,13 +22,17 @@ defmodule GraphQL.Relay.Mixfile do
 
   def application do
     [
-      applications: [:logger, :ecto],
+      applications: applications(Mix.env),
       env: [
         schema_module: StarWars.Schema, # Module with a .schema function that returns your GraphQL schema
         schema_json_path: "./schema.json"
       ]
     ]
   end
+  
+  defp applications(:test), do: applications(:prod) ++ [:ecto]
+  defp applications(:dev), do: applications(:prod) ++ [:ecto]
+  defp applications(_), do: [:logger]
 
   defp deps do
     [


### PR DESCRIPTION
Including graphql_relay in projects which do not use ecto causes problems,
because the ecto dependency here is only required for test, and is not installed
by Mix by default when including graphql_relay as a dependency. This means
that the application won't boot, as it can't find :ecto on launch.
